### PR TITLE
Fix: Adjust dashboard logo positioning and size for better layout

### DIFF
--- a/src/components/LandingPage/MainComponent/styles.css
+++ b/src/components/LandingPage/MainComponent/styles.css
@@ -51,9 +51,9 @@
 }
 .dashboard-logo {
   position: absolute;
-  left: 50%;
-  width: 350px;
-  top: 16%;
+  left: 35%;
+  width: 465px;
+  top: -70px;
   transform: translate(-50%, -76%) scaleX(1);
 }
 


### PR DESCRIPTION
This pull request makes a small adjustment to the positioning and size of the `.dashboard-logo` element in the landing page's main component CSS. The logo is now larger and positioned further left and higher up the page.